### PR TITLE
Add MongoDB, https and two fixers

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -16,3 +16,8 @@ requires 'Catmandu::MAB2';
 requires 'Catmandu::OAI';
 requires 'Catmandu::Solr';
 requires 'Catmandu::RDF';
+requires 'Catmandu::Store::MongoDB';
+requires 'Catmandu::Store::ElasticSearch';
+requires 'LWP::Protocol::https';
+requires 'Catmandu::Fix::marc_spec';
+requires 'Catmandu::Fix::author_names';


### PR DESCRIPTION
I'm not sure how you envision this image, but to me it seems more useful if it provides a quite rich collection of importers, exporters and stores, to provide a quick and easy entry to using Catmandu without having to extend the package yourself.

In this PR I've just added a few packages I needed, but what do you think about extending it even more to be more or less a complete collection of Catmandu packages?

The https package is needed e.g. for harvesting from a https-enabled
OAI-PMH endpoint.
